### PR TITLE
Reworked the way menu labels are built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,17 @@ php:
   - 7.3
 
 env:
-  - SYMFONY_VERSION="3.3.*"
   - SYMFONY_VERSION="3.4.*"
-  - SYMFONY_VERSION="4.0.*"
-  - SYMFONY_VERSION="4.1.*"
   - SYMFONY_VERSION="4.2.*"
+  - SYMFONY_VERSION="4.3.*"
 
 matrix:
   exclude:
     # Symfony >= 4.0 PHP requirement is ^7.1.3
     - php: 7.0
-      env: SYMFONY_VERSION="4.0.*"
-    - php: 7.0
-      env: SYMFONY_VERSION="4.1.*"
-    - php: 7.0
       env: SYMFONY_VERSION="4.2.*"
+    - php: 7.0
+      env: SYMFONY_VERSION="4.3.*"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - rm -rf composer.lock vendor/
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/workflow:${SYMFONY_VERSION}" --no-update; fi;
 
-install: composer install --prefer-dist --no-interaction
+install: COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install --prefer-dist --no-interaction
 
 script:
   - vendor/bin/phpunit --coverage-clover=build/coverage/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   - SYMFONY_VERSION="3.3.*"
   - SYMFONY_VERSION="3.4.*"
   - SYMFONY_VERSION="4.0.*"
   - SYMFONY_VERSION="4.1.*"
-  - SYMFONY_VERSION="4.2.x-dev"
+  - SYMFONY_VERSION="4.2.*"
 
 matrix:
   exclude:
@@ -20,7 +21,7 @@ matrix:
     - php: 7.0
       env: SYMFONY_VERSION="4.1.*"
     - php: 7.0
-      env: SYMFONY_VERSION="4.2.x-dev"
+      env: SYMFONY_VERSION="4.2.*"
 
 sudo: false
 
@@ -29,10 +30,10 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - composer selfupdate
+  - rm -rf composer.lock vendor/
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/workflow:${SYMFONY_VERSION}" --no-update; fi;
 
-install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+install: composer install --prefer-dist --no-interaction
 
 script:
   - vendor/bin/phpunit --coverage-clover=build/coverage/clover.xml

--- a/src/Admin/Extension/WorkflowExtension.php
+++ b/src/Admin/Extension/WorkflowExtension.php
@@ -90,7 +90,7 @@ class WorkflowExtension extends AbstractAdminExtension
         $transitions = $workflow->getEnabledTransitions($subject);
 
         if (count($transitions) === 0) {
-            $this->noTransitions($menu);
+            $this->noTransitions($menu, $admin);
         } else {
             $this->transitionsDropdown($menu, $admin, $transitions, $subject);
         }
@@ -139,14 +139,18 @@ class WorkflowExtension extends AbstractAdminExtension
 
     /**
      * @param MenuItemInterface $menu
+     * @param AdminInterface    $admin
      */
-    protected function noTransitions(MenuItemInterface $menu)
+    protected function noTransitions(MenuItemInterface $menu, AdminInterface $admin)
     {
         if ($this->options['no_transition_display']) {
             $menu->addChild($this->options['no_transition_label'], [
                 'uri' => '#',
                 'attributes' => [
                     'icon' => $this->options['no_transition_icon'],
+                ],
+                'extras' => [
+                    'translation_domain' => $admin->getTranslationDomain(),
                 ],
             ]);
         }
@@ -164,6 +168,9 @@ class WorkflowExtension extends AbstractAdminExtension
             'attributes' => [
                 'dropdown' => true,
                 'icon' => $this->options['dropdown_transitions_icon'],
+            ],
+            'extras' => [
+                'translation_domain' => $admin->getTranslationDomain(),
             ],
         ]);
 
@@ -183,6 +190,9 @@ class WorkflowExtension extends AbstractAdminExtension
         $options = [
             'uri' => $this->generateTransitionUri($admin, $transition, $subject),
             'attributes' => [],
+            'extras' => [
+                'translation_domain' => $admin->getTranslationDomain(),
+            ],
         ];
 
         if ($icon = $this->getTransitionIcon($transition)) {
@@ -190,7 +200,7 @@ class WorkflowExtension extends AbstractAdminExtension
         }
 
         $menu->addChild(
-            $admin->getLabelTranslatorStrategy()->getLabel($transition->getName(), 'workflow'),
+            $admin->getLabelTranslatorStrategy()->getLabel($transition->getName(), 'workflow', 'transition'),
             $options
         );
     }

--- a/tests/Admin/Extension/WorkflowExtensionTest.php
+++ b/tests/Admin/Extension/WorkflowExtensionTest.php
@@ -11,7 +11,6 @@ use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Workflow\Registry;
 use Symfony\Component\Workflow\StateMachine;
-use Symfony\Component\Workflow\SupportStrategy\InstanceOfSupportStrategy;
 use Yokai\SonataWorkflow\Admin\Extension\WorkflowExtension;
 use Yokai\SonataWorkflow\Controller\WorkflowController;
 use Yokai\SonataWorkflow\Tests\PullRequest;
@@ -36,7 +35,7 @@ class WorkflowExtensionTest extends \PHPUnit_Framework_TestCase
         self::assertSame('/pull-request/{id}/workflow/transition/{transition}/apply', $route->getPath());
         self::assertNotEmpty($defaults = $route->getDefaults());
         self::assertArrayHasKey('_controller', $defaults);
-        self::assertSame(WorkflowController::class.':workflowApplyTransitionAction', $defaults['_controller']);
+        self::assertSame(WorkflowController::class.'::workflowApplyTransitionAction', $defaults['_controller']);
         self::assertArrayHasKey('_sonata_admin', $defaults);
         self::assertSame('pull_request', $defaults['_sonata_admin']);
     }

--- a/tests/Admin/Extension/WorkflowExtensionTest.php
+++ b/tests/Admin/Extension/WorkflowExtensionTest.php
@@ -36,7 +36,7 @@ class WorkflowExtensionTest extends \PHPUnit_Framework_TestCase
         self::assertSame('/pull-request/{id}/workflow/transition/{transition}/apply', $route->getPath());
         self::assertNotEmpty($defaults = $route->getDefaults());
         self::assertArrayHasKey('_controller', $defaults);
-        self::assertSame(WorkflowController::class.'::workflowApplyTransitionAction', $defaults['_controller']);
+        self::assertSame(WorkflowController::class.':workflowApplyTransitionAction', $defaults['_controller']);
         self::assertArrayHasKey('_sonata_admin', $defaults);
         self::assertSame('pull_request', $defaults['_sonata_admin']);
     }
@@ -106,13 +106,14 @@ class WorkflowExtensionTest extends \PHPUnit_Framework_TestCase
 
         /** @var AdminInterface|ObjectProphecy $admin */
         $admin = $this->prophesize(AdminInterface::class);
+        $admin->getTranslationDomain()->willReturn('admin');
         $admin->getLabelTranslatorStrategy()->willReturn($labelStrategy->reveal());
         $admin->getSubject()->willReturn($pullRequest);
 
         foreach ($transitions as $transition) {
-            $labelStrategy->getLabel($transition, 'workflow')
+            $labelStrategy->getLabel($transition, 'workflow', 'transition')
                 ->shouldBeCalledTimes(1)
-                ->willReturn('transition.'.$transition);
+                ->willReturn('workflow.transition.'.$transition);
             $admin->generateObjectUrl('workflow_apply_transition', $pullRequest, ['transition' => $transition])
                 ->shouldBeCalledTimes(1)
                 ->willReturn('/pull-request/42/workflow/transition/'.$transition.'/apply');
@@ -135,11 +136,13 @@ class WorkflowExtensionTest extends \PHPUnit_Framework_TestCase
             self::assertNull($child = $menu->getChild('workflow_transitions'));
             self::assertNotNull($child = $menu->getChild('workflow_transitions_empty'));
             self::assertSame('#', $child->getUri());
+            self::assertSame('admin', $child->getExtra('translation_domain'));
             self::assertFalse($child->hasChildren());
             self::assertEmpty($child->getChildren());
         } else {
             self::assertNull($child = $menu->getChild('workflow_transitions_empty'));
             self::assertNotNull($child = $menu->getChild('workflow_transitions'));
+            self::assertSame('admin', $child->getExtra('translation_domain'));
             self::assertTrue($child->getAttribute('dropdown'));
             self::assertSame('fa fa-code-fork', $child->getAttribute('icon'));
             self::assertTrue($child->hasChildren());
@@ -150,8 +153,9 @@ class WorkflowExtensionTest extends \PHPUnit_Framework_TestCase
                     $icon = 'fa fa-times';
                 }
 
-                self::assertNotNull($item = $child->getChild('transition.'.$transition));
+                self::assertNotNull($item = $child->getChild('workflow.transition.'.$transition));
                 self::assertSame('/pull-request/42/workflow/transition/'.$transition.'/apply', $item->getUri());
+                self::assertSame('admin', $item->getExtra('translation_domain'));
                 self::assertSame($icon, $item->getAttribute('icon'));
             }
         }


### PR DESCRIPTION
- use admin translation domain as extra parameter everywhere (see issue #7)
- fill label translator strategy type for transitions (see issue #8)
