### PR TITLE
Added extension options to handle view & apply transitions permissions

### DIFF
--- a/src/Admin/Extension/WorkflowExtension.php
+++ b/src/Admin/Extension/WorkflowExtension.php
@@ -7,6 +7,7 @@ use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Workflow\Exception\InvalidArgumentException;
 use Symfony\Component\Workflow\Registry;
 use Symfony\Component\Workflow\Transition;
@@ -82,6 +83,12 @@ class WorkflowExtension extends AbstractAdminExtension
         }
 
         try {
+            $admin->checkAccess('viewTransitions', $subject);
+        } catch (AccessDeniedException $exception) {
+            return;
+        }
+
+        try {
             $workflow = $this->getWorkflow($subject, $this->options['workflow_name']);
         } catch (InvalidArgumentException $exception) {
             return;
@@ -94,6 +101,17 @@ class WorkflowExtension extends AbstractAdminExtension
         } else {
             $this->transitionsDropdown($menu, $admin, $transitions, $subject);
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAccessMapping(AdminInterface $admin)
+    {
+        return [
+            'viewTransitions' => $this->options['view_transitions_role'],
+            'applyTransitions' => $this->options['apply_transitions_role'],
+        ];
     }
 
     /**
@@ -124,6 +142,8 @@ class WorkflowExtension extends AbstractAdminExtension
                 'dropdown_transitions_icon' => 'fa fa-code-fork',
                 'transitions_default_icon' => null,
                 'transitions_icons' => [],
+                'view_transitions_role' => 'EDIT',
+                'apply_transitions_role' => 'EDIT',
             ])
             ->setAllowedTypes('render_actions', ['string[]'])
             ->setAllowedTypes('workflow_name', ['string', 'null'])
@@ -134,6 +154,8 @@ class WorkflowExtension extends AbstractAdminExtension
             ->setAllowedTypes('dropdown_transitions_icon', ['string', 'null'])
             ->setAllowedTypes('transitions_default_icon', ['string', 'null'])
             ->setAllowedTypes('transitions_icons', ['array'])
+            ->setAllowedTypes('view_transitions_role', ['string'])
+            ->setAllowedTypes('apply_transitions_role', ['string'])
         ;
     }
 

--- a/src/Admin/Extension/WorkflowExtension.php
+++ b/src/Admin/Extension/WorkflowExtension.php
@@ -78,13 +78,7 @@ class WorkflowExtension extends AbstractAdminExtension
         }
 
         $subject = $admin->getSubject();
-        if (null === $subject) {
-            return;
-        }
-
-        try {
-            $admin->checkAccess('viewTransitions', $subject);
-        } catch (AccessDeniedException $exception) {
+        if (null === $subject || !$this->isGrantedView($admin, $subject)) {
             return;
         }
 
@@ -210,12 +204,15 @@ class WorkflowExtension extends AbstractAdminExtension
     protected function transitionsItem(MenuItemInterface $menu, AdminInterface $admin, Transition $transition, $subject)
     {
         $options = [
-            'uri' => $this->generateTransitionUri($admin, $transition, $subject),
             'attributes' => [],
             'extras' => [
                 'translation_domain' => $admin->getTranslationDomain(),
             ],
         ];
+
+        if ($this->isGrantedApply($admin, $subject)) {
+            $options['uri'] = $this->generateTransitionUri($admin, $transition, $subject);
+        }
 
         if ($icon = $this->getTransitionIcon($transition)) {
             $options['attributes']['icon'] = $icon;
@@ -255,5 +252,39 @@ class WorkflowExtension extends AbstractAdminExtension
             $subject,
             ['transition' => $transition->getName()]
         );
+    }
+
+    /**
+     * @param AdminInterface $admin
+     * @param object         $subject
+     *
+     * @return bool
+     */
+    protected function isGrantedView(AdminInterface $admin, $subject)
+    {
+        try {
+            $admin->checkAccess('viewTransitions', $subject);
+        } catch (AccessDeniedException $exception) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param AdminInterface $admin
+     * @param object         $subject
+     *
+     * @return bool
+     */
+    protected function isGrantedApply(AdminInterface $admin, $subject)
+    {
+        try {
+            $admin->checkAccess('applyTransitions', $subject);
+        } catch (AccessDeniedException $exception) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Controller/WorkflowControllerTrait.php
+++ b/src/Controller/WorkflowControllerTrait.php
@@ -64,7 +64,7 @@ trait WorkflowControllerTrait
         }
 
         $this->admin->setSubject($existingObject);
-        $this->admin->checkAccess('edit', $existingObject);
+        $this->admin->checkAccess('applyTransitions', $existingObject);
 
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 

--- a/tests/Controller/WorkflowControllerTest.php
+++ b/tests/Controller/WorkflowControllerTest.php
@@ -124,7 +124,7 @@ class WorkflowControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->getObject(42)->shouldBeCalledTimes(1)
             ->willReturn($subject = new PullRequest());
         $this->admin->setSubject($subject)->shouldBeCalledTimes(1);
-        $this->admin->checkAccess('edit', $subject)->shouldBeCalledTimes(1);
+        $this->admin->checkAccess('applyTransitions', $subject)->shouldBeCalledTimes(1);
         $this->admin->getNormalizedIdentifier($subject)->shouldBeCalledTimes(1)->willReturn(42);
 
         $this->controller()->workflowApplyTransitionAction($this->request);
@@ -144,7 +144,7 @@ class WorkflowControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->getObject(42)->shouldBeCalledTimes(1)
             ->willReturn($subject = new PullRequest());
         $this->admin->setSubject($subject)->shouldBeCalledTimes(1);
-        $this->admin->checkAccess('edit', $subject)->shouldBeCalledTimes(1);
+        $this->admin->checkAccess('applyTransitions', $subject)->shouldBeCalledTimes(1);
         $this->admin->getNormalizedIdentifier($subject)->shouldBeCalledTimes(1)->willReturn(42);
 
         $this->controller()->workflowApplyTransitionAction($this->request);
@@ -167,7 +167,7 @@ class WorkflowControllerTest extends \PHPUnit_Framework_TestCase
             ->willReturn($subject = new PullRequest());
         $this->admin->toString($subject)->shouldBeCalledTimes(1)->willReturn('pr42');
         $this->admin->setSubject($subject)->shouldBeCalledTimes(1);
-        $this->admin->checkAccess('edit', $subject)->shouldBeCalledTimes(1);
+        $this->admin->checkAccess('applyTransitions', $subject)->shouldBeCalledTimes(1);
         $this->admin->getNormalizedIdentifier($subject)->shouldBeCalledTimes(1)->willReturn(42);
 
         $this->controller()->workflowApplyTransitionAction($this->request);
@@ -189,7 +189,7 @@ class WorkflowControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->getObject(42)->shouldBeCalledTimes(1)
             ->willReturn($subject = new PullRequest());
         $this->admin->setSubject($subject)->shouldBeCalledTimes(1);
-        $this->admin->checkAccess('edit', $subject)->shouldBeCalledTimes(1);
+        $this->admin->checkAccess('applyTransitions', $subject)->shouldBeCalledTimes(1);
         $this->admin->getNormalizedIdentifier($subject)->shouldBeCalledTimes(1)->willReturn(42);
         $this->admin->update($subject)->shouldBeCalledTimes(1)->willThrow(new ModelManagerException('phpunit error'));
 
@@ -213,7 +213,7 @@ class WorkflowControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->generateObjectUrl('edit', $subject)->shouldBeCalledTimes(1)
             ->willReturn('/pull-request/42/edit');
         $this->admin->setSubject($subject)->shouldBeCalledTimes(1);
-        $this->admin->checkAccess('edit', $subject)->shouldBeCalledTimes(1);
+        $this->admin->checkAccess('applyTransitions', $subject)->shouldBeCalledTimes(1);
         $this->admin->getNormalizedIdentifier($subject)->shouldBeCalledTimes(1)->willReturn(42);
         $this->admin->hasRoute('edit')->shouldBeCalledTimes(1)->willReturn(false);
         $this->admin->hasRoute('show')->shouldBeCalledTimes(1)->willReturn(false);
@@ -248,7 +248,7 @@ class WorkflowControllerTest extends \PHPUnit_Framework_TestCase
             ->willReturn($subject = new PullRequest());
         $this->admin->toString($subject)->shouldBeCalledTimes(1)->willReturn('pr42');
         $this->admin->setSubject($subject)->shouldBeCalledTimes(1);
-        $this->admin->checkAccess('edit', $subject)->shouldBeCalledTimes(1);
+        $this->admin->checkAccess('applyTransitions', $subject)->shouldBeCalledTimes(1);
         $this->admin->getNormalizedIdentifier($subject)->shouldBeCalledTimes(1)->willReturn(42);
         $this->admin->update($subject)->shouldBeCalledTimes(1)->willReturn($subject);
 
@@ -276,7 +276,7 @@ class WorkflowControllerTest extends \PHPUnit_Framework_TestCase
             ->willReturn($subject = new PullRequest());
         $this->admin->toString($subject)->shouldBeCalledTimes(1)->willReturn('pr42');
         $this->admin->setSubject($subject)->shouldBeCalledTimes(1);
-        $this->admin->checkAccess('edit', $subject)->shouldBeCalledTimes(1);
+        $this->admin->checkAccess('applyTransitions', $subject)->shouldBeCalledTimes(1);
         $this->admin->getNormalizedIdentifier($subject)->shouldBeCalledTimes(1)->willReturn(42);
         $this->admin->hasRoute('edit')->shouldBeCalledTimes(1)->willReturn(false);
         $this->admin->hasRoute('show')->shouldBeCalledTimes(1)->willReturn(false);
@@ -311,7 +311,7 @@ class WorkflowControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->getObject(42)->shouldBeCalledTimes(1)
             ->willReturn($subject = new PullRequest());
         $this->admin->setSubject($subject)->shouldBeCalledTimes(1);
-        $this->admin->checkAccess('edit', $subject)->shouldBeCalledTimes(1);
+        $this->admin->checkAccess('applyTransitions', $subject)->shouldBeCalledTimes(1);
         $this->admin->getNormalizedIdentifier($subject)->shouldBeCalledTimes(1)->willReturn(42);
         $this->admin->update($subject)->shouldNotBeCalled();
 


### PR DESCRIPTION
As suggested in #14, this PR introduce 2 options in the WorkflowExtension so you will be able to customize the required role related to the view & apply transitions