### PR TITLE
Allow PHP 8.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
             symfony-version: 5.1.*
           - php-version: 7.4
             symfony-version: 5.1.*
+          - php-version: 8.0
+            symfony-version: 5.1.*
 
     steps:
       - name: "Checkout"
@@ -48,7 +50,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: 7.4
+          - php-version: 8.0
             symfony-version: 5.1.*
 
     steps:
@@ -75,7 +77,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: 7.4
+          - php-version: 8.0
             symfony-version: 5.1.*
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,16 +14,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: 7.1
+          - php-version: 7.3
             symfony-version: 4.4.*
+          - php-version: 7.3
+            symfony-version: 5.2.*
           - php-version: 7.4
-            symfony-version: 4.4.*
-          - php-version: 7.2
-            symfony-version: 5.1.*
-          - php-version: 7.4
-            symfony-version: 5.1.*
+            symfony-version: 5.2.*
           - php-version: 8.0
-            symfony-version: 5.1.*
+            symfony-version: 5.2.*
 
     steps:
       - name: "Checkout"
@@ -51,7 +49,7 @@ jobs:
       matrix:
         include:
           - php-version: 8.0
-            symfony-version: 5.1.*
+            symfony-version: 5.2.*
 
     steps:
       - name: "Checkout"
@@ -78,7 +76,7 @@ jobs:
       matrix:
         include:
           - php-version: 8.0
-            symfony-version: 5.1.*
+            symfony-version: 5.2.*
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     }
   },
   "require": {
-    "php": "^7.1|^8.0",
+    "php": "^7.3|^8.0",
     "sonata-project/admin-bundle": "^3.0",
     "symfony/workflow": "^4.4|^5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5|^8.5|^9.5",
+    "phpunit/phpunit": "^8.5|^9.5",
     "squizlabs/php_codesniffer": "^3.5"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     }
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.1|^8.0",
     "sonata-project/admin-bundle": "^3.0",
     "symfony/workflow": "^4.4|^5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5",
+    "phpunit/phpunit": "^7.5|^8.5|^9.5",
     "squizlabs/php_codesniffer": "^3.5"
   }
 }

--- a/tests/Controller/WorkflowControllerTest.php
+++ b/tests/Controller/WorkflowControllerTest.php
@@ -59,8 +59,10 @@ class WorkflowControllerTest extends TestCase
      */
     private $flashBag;
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->container = $this->prophesize(ContainerInterface::class);
         $this->admin = $this->prophesize(AdminInterface::class);
         $this->registry = new Registry();


### PR DESCRIPTION
Support for PHP < 7.3 is also dropped since it was already dropped from sonata-project/admin-bundle 3.x.