### PR TITLE
Changed return type of WorkflowControllerTrait::getWorkflow for WorkflowInterface

### DIFF
--- a/src/Controller/WorkflowControllerTrait.php
+++ b/src/Controller/WorkflowControllerTrait.php
@@ -131,7 +131,7 @@ trait WorkflowControllerTrait
     /**
      * @throws InvalidArgumentException
      */
-    protected function getWorkflow(object $object): Workflow
+    protected function getWorkflow(object $object): WorkflowInterface
     {
         $registry = $this->workflowRegistry ?? null;
         if ($registry === null) {

--- a/src/Controller/WorkflowControllerTrait.php
+++ b/src/Controller/WorkflowControllerTrait.php
@@ -17,6 +17,7 @@ use Symfony\Component\Workflow\Exception\InvalidArgumentException;
 use Symfony\Component\Workflow\Exception\LogicException;
 use Symfony\Component\Workflow\Registry;
 use Symfony\Component\Workflow\Workflow;
+use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
  *


### PR DESCRIPTION
With Symfony 6.4, I get this error:
Yokai\SonataWorkflow\Controller\WorkflowController::getWorkflow(): Return value must be of type Symfony\Component\Workflow\Workflow, Symfony\Component\Workflow\Debug\TraceableWorkflow returned

Changing the return value to WorkflowInterface corrects the problem.